### PR TITLE
armor casting

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -357,9 +357,9 @@ This function restores all organs.
 /mob/living/carbon/human/proc/degrade_affected_armor(var/damage,var/damage_type = BRUTE,var/obj/item/organ/external/def_zone = null)
 	def_zone = get_organ(def_zone)
 	//Code (mostly) ripped from human_defense.dm's getarmor_organ proc.
-	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
+	var/list/protective_gear = list(head, wear_mask, wear_suit, back, w_uniform, gloves, shoes)
 	for(var/gear in protective_gear)
-		var/obj/item/clothing/C = gear
+		var/obj/item/C = gear
 		if(gear && istype(C))
 			if(C.body_parts_covered & def_zone.body_part)
 				if(C.armor_thickness == 0 || isnull(C.armor_thickness))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -100,10 +100,10 @@ cloak disrupt override
 	if(!def_zone)
 		return 0
 	var/protection = 0
-	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
+	var/list/protective_gear = list(head, wear_mask, wear_suit, back, w_uniform, gloves, shoes)
 	for(var/gear in protective_gear)
-		if(gear && istype(gear ,/obj/item/clothing))
-			var/obj/item/clothing/C = gear
+		if(gear && istype(gear ,/obj/item))
+			var/obj/item/C = gear
 			if(istype(C) && C.body_parts_covered & def_zone.body_part)
 				var/effective_armor_thickness = 1
 				if(!isnull(initial(C.armor_thickness)))


### PR DESCRIPTION
Rather than armor checks strictly checking for /obj/item/clothing, it now checks for /obj/item

/obj/item has all the armor variables that clothing has, so there was no point in having it only check for /obj/item/clothing

This is required for something I'm working on (flamethrower with fuel tank on back) so that, should the person get shot and it collides with the tank, the tank would get penetrated and potentially explode.