### PR TITLE
Fixes invisible guns

### DIFF
--- a/icons/FoF/code/guns_ammo.dm
+++ b/icons/FoF/code/guns_ammo.dm
@@ -1,3 +1,5 @@
+#define NEEDS_RESPRITE 'icons/FoF/weaponsnew.dmi'
+
 /obj/item/weapon/gun/projectile/wwi
 	icon = 'icons/FoF/munitionsx32.dmi'
 	force = 10
@@ -7,6 +9,7 @@
 /obj/item/weapon/gun/projectile/wwi/mg08
 	name = "\improper MG 08-15"
 	desc = "A lightened and thus more portable version of the original german MG08 heavy machinegun. Supports 50-round drum feed system. Uses 7.92mm ammo."
+	icon = NEEDS_RESPRITE
 	icon_state = "mg08"
 	item_state = "mg08_w"
 	caliber = "a792"
@@ -42,6 +45,7 @@
 /obj/item/weapon/gun/projectile/wwi/lewis
 	name = "\improper Lewis gun"
 	desc = "An offshoot of the British Vickers machine gun, known by its distinctive barrel cooling shroud and top mounted 47-round pan magazine. Uses .303 British ammo."
+	icon = NEEDS_RESPRITE
 	icon_state = "lewis"
 	item_state = "mg08_w"
 	caliber = "a303"
@@ -76,6 +80,7 @@
 /obj/item/weapon/gun/projectile/wwi/chauchat
 	name = "\improper FM Chauchat"
 	desc = "A French light machine gun, known for overheating and frequent failures. Supports 20-round magazine feed system. Uses 8mm ammo."
+	icon = NEEDS_RESPRITE
 	icon_state = "chauchat"
 	item_state = "chauchat"
 	caliber = "8mm"
@@ -110,6 +115,7 @@
 
 /obj/item/weapon/gun/projectile/wwi/ruby
 	name = "\improper Ruby"
+	icon = NEEDS_RESPRITE
 	desc = "A cheap Spanish pistol, favoured by the French army for its portability and decent firepower. Uses .32 ACP."
 	magazine_type = /obj/item/ammo_magazine/c32acp
 	ammo_type = /obj/item/ammo_casing/c32acp || /obj/item/ammo_casing/c32acp
@@ -130,6 +136,7 @@
 
 /obj/item/weapon/gun/projectile/wwi/mauser
 	name = "\improper Mauser C96"
+	icon = NEEDS_RESPRITE
 	desc = "A Mauser, expensive yet reliable German pistol. Takes 9mm stripper clips."
 	magazine_type = /obj/item/ammo_magazine/c9mm
 	fire_sound = 'sound/weapons/ruby.ogg'
@@ -230,6 +237,7 @@
 /obj/item/weapon/gun/projectile/wwi/bolt/g98rifle
 	name = "\improper G98 rifle"
 	desc = "A simple yet reliable German rifle. Supports 7.92mm stripper clips."
+	icon = NEEDS_RESPRITE
 	icon_state = "g98"
 	item_state = "ba_rifle"
 	magazine_type = /obj/item/ammo_magazine/g792
@@ -258,6 +266,7 @@
 /obj/item/weapon/gun/projectile/wwi/bolt/lebel
 	name = "\improper Lebel"
 	desc = "A sturdy old French rifle, able to be used as a club in a pinch. Uses 8mm ammo."
+	icon = NEEDS_RESPRITE
 	icon_state = "lebel"
 	caliber = "8mm"
 	fire_sound = 'sound/weapons/lebel.ogg'
@@ -270,6 +279,7 @@
 /obj/item/weapon/gun/projectile/wwi/bolt/smle
 	name = "\improper Lee-Enfield"
 	desc = "The British Army's standard rifle from its official adoption in 1895. Takes 5-round .303 British stripper clips."
+	icon = NEEDS_RESPRITE
 	icon_state = "smle"
 	slot_flags = SLOT_BACK
 	fire_sound = 'sound/weapons/smle.ogg'
@@ -289,6 +299,7 @@
 /obj/item/weapon/gun/projectile/wwi/bolt/smle/scoped
 	name = "\improper Scoped Lee-Enfield"
 	desc = "The British Army's standard rifle from its official adoption in 1895. This one has an attached scope. Takes 5-round .303 British stripper clips."
+	icon = NEEDS_RESPRITE
 	icon_state = "smle_scoped"
 	accuracy = 2
 	scoped_accuracy = 6


### PR DESCRIPTION
Adds a NEEDS_RESPRITE define so, while we don't have any invisible guns, it'll act as the TODO marker for certain weapons that need to be remade visually