### PR TITLE
Fixes iron pills runtiming

### DIFF
--- a/icons/FoF/code/items_objects.dm
+++ b/icons/FoF/code/items_objects.dm
@@ -4,6 +4,7 @@
 	icon_state = "pill18"
 
 /obj/item/weapon/reagent_containers/pill/iron/New()
+	..()
 	reagents.add_reagent(/datum/reagent/iron, 20)
 
 /obj/item/weapon/storage/pill_bottle/iron


### PR DESCRIPTION
In a previous PR #13 partial pathing was purged, but the supercall was also dropped from the iron pill's New()

This re-adds it. PRs should stop failing travis from the "check if there are any runtimes" check now.