### PR TITLE
Radial menu to view items on turf, also a rework

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -104,11 +104,6 @@
 		return
 	..()
 
-/mob/living/silicon/ai/MiddleClickOn(var/atom/A)
-	if(!control_disabled && A.AIMiddleClick(src))
-		return
-	..()
-
 /*
 	The following criminally helpful code is just the previous code cleaned up;
 	I have no idea why it was in atoms.dm instead of respective files.
@@ -163,20 +158,6 @@
 
 /obj/machinery/teleport/station/AIAltClick()
 	testfire()
-
-/atom/proc/AIMiddleClick(var/mob/living/silicon/user)
-	return 0
-
-/obj/machinery/door/airlock/AIMiddleClick() // Toggles door bolt lights.
-
-	if(..())
-		return
-
-	if(!src.lights)
-		Topic(src, list("command"="lights", "activate" = "1"))
-	else
-		Topic(src, list("command"="lights", "activate" = "0"))
-	return 1
 
 //
 // Override AdjacentQuick for AltClicking

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -228,7 +228,7 @@
 			choice_references["[thing.name]"] = thing
 
 	var/list/choice = show_radial_menu(src, T, all_choices)
-	if(!choice.len)
+	if(!choice || !choice.len)
 		return 0
 	
 	if(!(choice[1] in choice_references))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -213,12 +213,39 @@
 
 /*
 	Middle click
-	Only used for swapping hands
+	Used for radial menu stuff
 */
 /mob/proc/MiddleClickOn(var/atom/A)
-	swap_hand()
-	return
+	var/turf/T = get_turf(A)
+	if(!T)
+		return 0
 
+	var/list/all_choices = list()
+	var/list/choice_references = list()
+	for(var/obj/item/thing in T)
+		if(istype(thing))
+			all_choices += new /datum/radial_menu_choice(thing.name, image(thing.icon, thing.icon_state, thing.dir), thing.desc)
+			choice_references["[thing.name]"] = thing
+
+	var/list/choice = show_radial_menu(src, T, all_choices)
+	if(!choice.len)
+		return 0
+	
+	if(!(choice[1] in choice_references))
+		return 0
+
+	if(!choice_references["[choice[1]]"])
+		return 0
+
+	if(!Adjacent(choice_references["[choice[1]]"]))
+		return 0
+
+	if(choice["shift"]) //it was shiftclicked
+		var/atom/selA = choice_references["[choice[1]]"]
+		selA.examine(src)
+	else
+		src.put_in_active_hand(choice_references["[choice[1]]"])
+	return 1
 // In case of use break glass
 /*
 /atom/proc/MiddleClick(var/mob/M as mob)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -44,7 +44,11 @@
 
 	next_click = world.time + 1
 
-	var/list/modifiers = params2list(params)
+	var/list/modifiers
+	if(islist(params))
+		modifiers = params
+	else
+		modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return 1
@@ -240,11 +244,9 @@
 	if(!Adjacent(choice_references["[choice[1]]"]))
 		return 0
 
-	if(choice["shift"]) //it was shiftclicked
-		var/atom/selA = choice_references["[choice[1]]"]
-		selA.examine(src)
-	else
-		src.put_in_active_hand(choice_references["[choice[1]]"])
+	var/atom/selA = choice_references["[choice[1]]"]
+	ClickOn(selA, choice.Copy(2))
+
 	return 1
 // In case of use break glass
 /*

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -93,11 +93,6 @@
 			return
 	return
 
-//Middle click cycles through selected modules.
-/mob/living/silicon/robot/MiddleClickOn(var/atom/A)
-	cycle_modules()
-	return
-
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
 /mob/living/silicon/robot/CtrlShiftClickOn(var/atom/A)

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -325,7 +325,7 @@
 	menu.set_choices(choices)
 	menu.show_to(user)
 	menu.wait()
-	if(!menu.gcDestroyed)
+	if(!menu.gc_destroyed)
 		var/answer = menu.selected_choice
 		qdel(menu)
 		current_user.radial_menus -= anchor

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -287,7 +287,7 @@
 		current_user.images -= menu_holder
 
 /datum/radial_menu/proc/wait()
-	while (!gcDestroyed && current_user && !finished && !selected_choice)
+	while (!gc_destroyed && current_user && !finished && !selected_choice)
 		if(istype(custom_check) && next_check < world.time)
 			if(!INVOKE_EVENT(custom_check, list()))
 				return

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -9,7 +9,7 @@
 
 /obj/screen/radial/slice
 	icon_state = "radial_slice"
-	var/choice
+	var/datum/radial_menu_choice/choice
 	var/next_page = FALSE
 	var/tooltip_desc
 
@@ -25,11 +25,14 @@
 	closeToolTip(usr)
 
 /obj/screen/radial/slice/Click(location, control, params)
-	if(usr.client == parent.current_user)
+	return choice.ClickOn(usr, params)
+
+/obj/screen/radial/slice/proc/selected(var/mob/user, var/list/modifier)
+	if(user.client == parent.current_user)
 		if(next_page)
 			parent.next_page()
 		else
-			parent.element_chosen(choice,usr)
+			parent.element_chosen(choice.value, modifier, user)
 
 /obj/screen/radial/center
 	name = "Close Menu"
@@ -40,16 +43,14 @@
 		parent.finished = TRUE
 
 /datum/radial_menu
-	var/list/choices = list() //List of choice id's
-	var/list/choices_icons = list() //choice_id -> icon
-	var/list/choices_values = list() //choice_id -> choice
-	var/list/choices_tooltips = list() //choice_id -> tooltip
+	var/list/choices = list() //List of /datum/radial_menu_choice
 	var/list/page_data = list() //list of choices per page
 
 	var/icon_file = 'icons/mob/radial.dmi'
 	var/tooltip_theme = "radial-default"
 
 	var/selected_choice
+	var/selected_modifier
 	var/list/obj/screen/elements = list()
 	var/obj/screen/radial/center/close_button
 	var/client/current_user
@@ -120,7 +121,7 @@
 			elements += new_element
 
 	var/page = 1
-	page_data = list(null)
+	page_data = list()
 	var/list/current = list()
 	var/list/choices_left = choices.Copy()
 	while(choices_left.len)
@@ -161,8 +162,9 @@
 	E.mouse_opacity = 0
 	E.choice = null
 	E.next_page = FALSE
+	E.choice = null
 
-/datum/radial_menu/proc/SetElement(obj/screen/radial/slice/E,choice_id,angle,anim,anim_order)
+/datum/radial_menu/proc/SetElement(obj/screen/radial/slice/E,/datum/radial_menu_choice/choice,angle,anim,anim_order)
 	//Position
 	var/py = round(cos(angle) * radius) + py_shift
 	var/px = round(sin(angle) * radius)
@@ -185,19 +187,17 @@
 		E.name = "Next Page"
 		E.next_page = TRUE
 		push(E.overlays, "radial_next")
+		E.choice = new /datum/radial_menu_choice() //default will do, we only need the logic
 	else
-		if(istext(choices_values[choice_id]))
-			E.name = choices_values[choice_id]
-		else
-			var/atom/movable/AM = choices_values[choice_id] //Movables only
-			E.name = AM.name
-		E.choice = choice_id
+		E.name = choice.name
+		E.choice = choice
+		choice.parent = E
 		E.maptext = null
 		E.next_page = FALSE
-		if(choices_icons[choice_id])
-			push(E.overlays,choices_icons[choice_id])
-		if(choices_tooltips[choice_id])
-			E.tooltip_desc = choices_tooltips[choice_id]
+		if(choice.img)
+			push(E.overlays,choice.img)
+		if(choice.tooltip)
+			E.tooltip_desc = choice.tooltip
 
 /datum/radial_menu/New(var/icon_file, var/tooltip_theme, var/radius, var/min_angle)
 	if(icon_file)
@@ -215,13 +215,11 @@
 
 /datum/radial_menu/proc/Reset()
 	choices.Cut()
-	choices_icons.Cut()
-	choices_values.Cut()
-	choices_tooltips.Cut()
 	current_page = 1
 
-/datum/radial_menu/proc/element_chosen(choice_id,mob/user)
-	selected_choice = choices_values[choice_id]
+/datum/radial_menu/proc/element_chosen(var/choice_id, var/list/modifier, var/mob/user)
+	selected_choice = choice_id
+	selected_modifier = modifier
 
 /datum/radial_menu/proc/get_next_id()
 	return "c_[choices.len]"
@@ -229,30 +227,14 @@
 /datum/radial_menu/proc/set_choices(var/list/new_choices)
 	if(choices.len)
 		Reset()
-	for(var/list/E in new_choices)
-		var/id = get_next_id()
-		choices += id
-		var/choice_name = E[1]
-		choices_values[id] = choice_name
+	//check if they are valid (no double values)
+	var/list/all_values = list()
+	for(var/datum/radial_menu_choice/choice in new_choices)
+		if(choice.value in all_values)
+			continue
 
-		if(E.len > 1)
-			var/extracted_image
-			var/choice_icon = E[2]
-			if(istext(choice_icon)) //a string representing an icon_state from our icon_file
-				extracted_image = extract_image(image(icon = icon_file, icon_state = choice_icon))
-			else
-				extracted_image = extract_image(choice_icon)
-			if(extracted_image)
-				choices_icons[id] = extracted_image
-
-		if(E.len > 2)
-			var/choice_tooltip = E[3]
-			choices_tooltips[id] = choice_tooltip
-
-		if(E.len > 3) // Radial's replacement for the actual name. Currently only used for talismans.
-			choice_name = E[4]
-			choices_values[id] = choice_name
-
+		all_values += choice.value
+		choices += choice
 	setup_menu()
 
 
@@ -302,6 +284,30 @@
 		custom_check.holder = null
 		custom_check = null
 	. = ..()
+
+/datum/radial_menu_choice
+	var/name
+	var/image/img
+	var/tooltip
+	var/obj/screen/radial/slice/parent
+	var/value
+
+/datum/radial_menu_choice/New(var/n_name, var/image/n_img, var/n_tooltip)
+	..()
+	if(istext(n_name))
+		name = n_name
+	if(istype(n_img))
+		img = n_img
+	if(istext(n_tooltip))
+		tooltip = n_tooltip
+
+/datum/radial_menu_choice/proc/ClickOn(var/mob/user, params)
+	if(istype(parent))
+		var/list/modifiers = params2list(params)
+		parent.selected(user, modifiers)
+		return 1
+	return 0
+
 /*
 	Presents radial menu to user anchored to anchor (or user if the anchor is currently in users screen)
 	Choices should be a list where list keys are movables or text used for element names and return value
@@ -326,7 +332,8 @@
 	menu.show_to(user)
 	menu.wait()
 	if(!menu.gc_destroyed)
-		var/answer = menu.selected_choice
+		var/list/answer = menu.selected_choice
+		answer += menu.modifier
 		qdel(menu)
 		current_user.radial_menus -= anchor
 		return answer

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -46,7 +46,7 @@
 	var/tooltip_theme = "radial-default"
 
 	var/selected_choice
-	var/selected_modifier
+	var/list/selected_modifiers
 	var/list/obj/screen/elements = list()
 	var/obj/screen/radial/center/close_button
 	var/client/current_user
@@ -208,12 +208,12 @@
 	choices.Cut()
 	current_page = 1
 
-/datum/radial_menu/proc/element_chosen(var/choice_id, var/list/modifier, var/mob/user)
+/datum/radial_menu/proc/element_chosen(var/choice_id, var/list/modifiers, var/mob/user)
 	if(choice_id == NEXT_PAGE_ID)
 		next_page()
 		return
 	selected_choice = choice_id
-	selected_modifier = modifier
+	selected_modifiers = modifiers
 
 /datum/radial_menu/proc/get_next_id()
 	return "c_[choices.len]"
@@ -297,7 +297,6 @@
 		tooltip = n_tooltip
 	if(istext(n_value))
 		value = n_value
-		
 
 /datum/radial_menu_choice/proc/ClickOn(var/mob/user, var/list/modifiers)
 	if(istype(parent))
@@ -335,7 +334,7 @@
 	menu.wait()
 	if(!menu.gc_destroyed)
 		var/list/answer = list(menu.selected_choice)
-		answer += menu.selected_modifier
+		answer += menu.selected_modifiers
 		qdel(menu)
 		current_user.radial_menus -= anchor
 		return answer

--- a/code/_onclick/rig.dm
+++ b/code/_onclick/rig.dm
@@ -29,12 +29,6 @@
 			to_chat(src, "Somehow you bugged the system. Setting your hardsuit mode to middle-click.")
 			hardsuit_click_mode = MIDDLE_CLICK
 
-/mob/living/MiddleClickOn(atom/A)
-	if(client && client.hardsuit_click_mode == MIDDLE_CLICK)
-		if(HardsuitClickOn(A))
-			return
-	..()
-
 /mob/living/AltClickOn(atom/A)
 	if(client && client.hardsuit_click_mode == ALT_CLICK)
 		if(HardsuitClickOn(A))

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -33,8 +33,6 @@ SUBSYSTEM_DEF(garbage)
 	var/list/qdel_list = list()	// list of all types that have been qdel()eted
 #endif
 
-/datum/var/gcDestroyed
-
 /datum/controller/subsystem/garbage/stat_entry()
 	var/msg = list()
 	msg += "Q:[queue.len]|TD:[totaldels]|TG:[totalgcs]|TGR:"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -19,8 +19,6 @@
 	var/item_state = null // Used to specify the item state for the on-mob overlays.
 
 /atom/movable/Destroy()
-	gcDestroyed = "Bye, world!"
-
 	for(var/atom/movable/AM in src)
 		qdel(AM)
 


### PR DESCRIPTION
this adds a menu to interact with items on a turf

this also features a massive rework of the radial menu, making it possible for you to
- receive click params with the selected choice
- add costum logic to individual choice onclicks (in the menu)

using more technical talk
- show_radial_menu no longer only returns the picked choice, but a list with the first entry being the picked choice and the other elements being the click params
- choices are no longer list but datum, so in theory you can create a child datum and make your own logic

PS: also ClickOn now accepts an already converted params list